### PR TITLE
Fixed HkGetClientID (#9)

### DIFF
--- a/source/HkFuncTools.cpp
+++ b/source/HkFuncTools.cpp
@@ -12,7 +12,13 @@ HK_ERROR HkGetClientID(bool& bIdString, uint& iClientID, const std::wstring &wsc
 			if((hkErr == HKE_AMBIGUOUS_SHORTCUT) || (hkErr == HKE_NO_MATCHING_PLAYER))
 				return hkErr;
 			if(hkErr == HKE_INVALID_SHORTCUT_STRING)
+			{
 				iClientID = HkGetClientIdFromCharname(wscCharname);
+				if (iClientID != (uint)-1)
+					return HKE_OK;
+				else
+					return HKE_PLAYER_NOT_LOGGED_IN;
+			}
 		}
 	}
 	return hkErr;


### PR DESCRIPTION
* Fixed HkGetClientID

Before most commands that require a clientID would error with HKE_INVALID_SHORTCUT_STRING. We have redefined modified HkGetClientID to return HKE_OK if it finds a valid ID from the charname.

* HkGetClientID: Corrected comparison and better error if player is not logged in